### PR TITLE
FAI-2064 - Fix issue where constraint issue was being incorrect raised

### DIFF
--- a/src/SFA.DAS.ApprenticeAccounts/Application/Commands/CreateOrUpdateApprenticeAccount/CreateOrUpdateApprenticeAccountCommandHandler.cs
+++ b/src/SFA.DAS.ApprenticeAccounts/Application/Commands/CreateOrUpdateApprenticeAccount/CreateOrUpdateApprenticeAccountCommandHandler.cs
@@ -27,7 +27,10 @@ public class CreateOrUpdateApprenticeAccountCommandHandler(IApprenticeContext ap
                 apprentice.UpdatedOn = DateTime.UtcNow;
             }
 
-            if (!apprentice.Email.Address.Equals(request.Email) && !string.IsNullOrEmpty(apprentice.GovUkIdentifier))
+            //This should cover the case where we have searched by gov identifier and have a different email returned
+            //in this instance, we check it doesnt match an already existing user that has a gov login account
+            //If they do exist with not gov identifier, we switch the identifier to that account 
+            if (!apprentice.Email.Address.Equals(request.Email, StringComparison.CurrentCultureIgnoreCase))
             {
                 var apprenticeByEmail = await apprenticeContext.FindByEmail(new MailAddress(request.Email));
                 if (apprenticeByEmail != null)


### PR DESCRIPTION
There was a missing check to ignore the casing of the email which would have result in a constraint exception being thrown when test@example.com did not match TEST@Example.com