### PR TITLE
Trigger added for AppLastLoggedIn changes for Logging Logins

### DIFF
--- a/src/SFA.DAS.ApprenticeAccounts.Database/SFA.DAS.ApprenticeAccounts.Database.sqlproj
+++ b/src/SFA.DAS.ApprenticeAccounts.Database/SFA.DAS.ApprenticeAccounts.Database.sqlproj
@@ -61,6 +61,7 @@
     <Folder Include="Views" />
     <Folder Include="Schemas" />
     <Folder Include="PostDeployment" />
+    <Folder Include="Triggers" />
   </ItemGroup>
   <ItemGroup>
     <Build Include="Tables\Apprentice.sql" />
@@ -74,6 +75,8 @@
     <None Include="PostDeployment\AddDefaultNotificationsPreferences.sql" />
     <Build Include="Tables\MyApprenticeship.sql" />
     <Build Include="Tables\ApprenticeArticle.sql" />
+    <Build Include="Tables\ApprenticeAppLogins.sql" />
+    <Build Include="Triggers\trg_Apprentice_LogAppLastLoggedIn.sql" />
   </ItemGroup>
   <ItemGroup>
     <PostDeploy Include="PostDeployment\PostDeployment.sql" />

--- a/src/SFA.DAS.ApprenticeAccounts.Database/Tables/ApprenticeAppLogins.sql
+++ b/src/SFA.DAS.ApprenticeAccounts.Database/Tables/ApprenticeAppLogins.sql
@@ -1,0 +1,7 @@
+﻿CREATE TABLE [dbo].[ApprenticeAppLogins] (
+    [Id] UNIQUEIDENTIFIER NOT NULL
+        CONSTRAINT DF_ApprenticeAppLogins_Id DEFAULT NEWID(),
+    [ApprenticeId] UNIQUEIDENTIFIER NOT NULL,
+    [LoginDateTime] DATETIME2 (7) NULL,
+    CONSTRAINT PK_ApprenticeAppLogins PRIMARY KEY CLUSTERED ([Id] ASC)
+);

--- a/src/SFA.DAS.ApprenticeAccounts.Database/Triggers/trg_Apprentice_LogAppLastLoggedIn.sql
+++ b/src/SFA.DAS.ApprenticeAccounts.Database/Triggers/trg_Apprentice_LogAppLastLoggedIn.sql
@@ -1,0 +1,21 @@
+﻿CREATE TRIGGER [dbo].[trg_Apprentice_LogAppLastLoggedIn]
+ON [dbo].[Apprentice]
+AFTER UPDATE
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    IF UPDATE(AppLastLoggedIn)
+    BEGIN
+        INSERT INTO [dbo].[ApprenticeAppLogins] (ApprenticeId, LoginDateTime)
+        SELECT 
+            i.[Id], 
+            i.[AppLastLoggedIn]
+        FROM inserted i
+        INNER JOIN deleted d ON i.[Id] = d.[Id]
+        WHERE 
+            (i.[AppLastLoggedIn] <> d.[AppLastLoggedIn] 
+             OR (i.[AppLastLoggedIn] IS NULL AND d.[AppLastLoggedIn] IS NOT NULL)
+             OR (i.[AppLastLoggedIn] IS NOT NULL AND d.[AppLastLoggedIn] IS NULL));
+    END
+END;

--- a/src/SFA.DAS.ApprenticeAccounts/Data/Models/ApprenticeAccountsDbContext.cs
+++ b/src/SFA.DAS.ApprenticeAccounts/Data/Models/ApprenticeAccountsDbContext.cs
@@ -47,6 +47,8 @@ namespace SFA.DAS.ApprenticeAccounts.Data.Models
             modelBuilder.Entity<Apprentice>(a =>
             {
                 a.ToTable("Apprentice");
+                a.ToTable(tb => tb.UseSqlOutputClause(false));
+
                 a.HasKey(e => e.Id);
                 a.Property(e => e.Email)
                  .HasConversion(
@@ -73,7 +75,7 @@ namespace SFA.DAS.ApprenticeAccounts.Data.Models
             modelBuilder.Entity<Preference>(p =>
             {
                 p.ToTable("Preference")
-                 .HasKey(p => p.PreferenceId);                
+                 .HasKey(p => p.PreferenceId);
             });
 
             modelBuilder.Entity<ApprenticeArticle>(p =>
@@ -81,9 +83,7 @@ namespace SFA.DAS.ApprenticeAccounts.Data.Models
                 p.ToTable("ApprenticeArticle")
                 .HasKey(m => new { m.Id, m.EntryId });
             });
-
-
-
+            
             modelBuilder.Entity<ApprenticePreferences>( ap =>
             {
                 ap.ToTable("ApprenticePreferences")


### PR DESCRIPTION
DbContext update: 
UseSqlOutput clause on apprentice Table

New Table:
ApprenticeAppLogins - Records apprenticeId and LoginDateTime

Trigger:
Based off Apprentice tables AppLastLoggedIn changes, new record is created in ApprenticeAppLogins table with Apprentice Id and the time of login with a unique Id